### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/octicons-modular/package.json
+++ b/packages/octicons-modular/package.json
@@ -30,6 +30,11 @@
   "sideEffects": [
     "/**/*.css"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hiendv/octicons-modular.git",
+    "directory": "packages/octicons-modular"
+  },
   "babel": {
     "presets": [
       "@babel/preset-env"

--- a/packages/octicons-react/package.json
+++ b/packages/octicons-react/package.json
@@ -30,6 +30,11 @@
   "dependencies": {
     "octicons-modular": "^1.0.7"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hiendv/octicons-modular.git",
+    "directory": "packages/octicons-react"
+  },
   "peerDependencies": {
     "prop-types": "^15.7.2",
     "react": "^17.0.2"

--- a/packages/octicons-vue/package.json
+++ b/packages/octicons-vue/package.json
@@ -30,6 +30,11 @@
   "dependencies": {
     "octicons-modular": "^1.0.7"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hiendv/octicons-modular.git",
+    "directory": "packages/octicons-vue"
+  },
   "peerDependencies": {
     "vue": "^2.6.14"
   }


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR.

Published NPM packages with repository information:
• octicons-modular
• octicons-react
• octicons-vue